### PR TITLE
refactor: use pymultihash instead of py-multihash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "py-multibase>=1.0.0,<2.0.0",
     "py-multicodec<0.3.0",
     "morphys>=1.0,<2.0",
-    "py-multihash>=0.2.0,<1.0.0",
+    "pymultihash>=0.8.0,<1.0.0",
 ]
 
 [project.urls]

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ requirements = [
     'py-multibase>=1.0.0,<2.0.0',
     'py-multicodec<0.3.0',
     'morphys>=1.0,<2.0',
-    'py-multihash>=0.2.0,<1.0.0',
+    'pymultihash>=0.8.0,<1.0.0',
 ]
 
 setup(

--- a/tests/test_cid.py
+++ b/tests/test_cid.py
@@ -1,4 +1,3 @@
-import hashlib
 import multihash
 import pytest
 import base58
@@ -17,8 +16,8 @@ ALLOWED_ENCODINGS = [encoding for encoding in ENCODINGS if encoding.code != b'\x
 
 @pytest.fixture(scope='session')
 def test_hash():
-    data = hashlib.sha256(b'hello world').hexdigest()
-    return multihash.encode(bytes.fromhex(data), 'sha2-256')
+    data = b'hello world'
+    return multihash.digest(data, 'sha2-256').encode()
 
 
 class TestCIDv0(object):


### PR DESCRIPTION
Using newest multihash package pymultihash